### PR TITLE
Remove superfluous BSRR code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/zig-cache/
-/zig-out/
+zig-cache/
+zig-out/
 *.swp
 *~

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After flashing the board you should see two blinking lights running around in op
 File `src/registers.zig` was generated using [rbino/svd4zig](https://github.com/rbino/svd4zig),
 see the Git submodule, using
 ```bash
-./svd2zig STM32F303.svd > src/registers.zig`
+./svd2zig STM32F303.svd > src/registers.zig
 ```
 
 File STM32F303.svd is from STMicroelectronics 'STM32F3 System View Description',

--- a/README.md
+++ b/README.md
@@ -84,8 +84,4 @@ https://www.st.com/content/ccc/resource/technical/ecad_models_and_symbols/svd/gr
 - Generate linker.ld based on https://github.com/libopencm3/libopencm3/tree/master/ld.
   (Perhaps as part of `zig build`? make libopencm3 a submodule probably.)
 
-- What is the difference between the following registers on a GPIO port?
-   * BSRR "GPIO port bit set/reset"
-   * ODR "GPIO port output data register"
-
 - Try out the other hardware on the STM32F3DISCOVERY board.

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,18 +52,6 @@ pub fn main() void {
         .MODER15 = 0b01, // left, green, LED 6
     });
 
-    // Set initial state: only top-left blue LED 4 = pin 8
-    regs.GPIOE.BSRR.modify(.{
-        .BS8 = 0,
-        .BS9 = 0,
-        .BS10 = 0,
-        .BS11 = 0,
-        .BS12 = 0,
-        .BS13 = 0,
-        .BS14 = 0,
-        .BS15 = 0,
-    });
-
     var j: u3 = 0;
     var k: u3 = 0;
 


### PR DESCRIPTION
Learned via the interwebs that, for a GPIO port,

- ODR updates all bits
  (and therefore requires a separate read
  if one wants to update a single bit);
- BRR sets all bits that are 1 to 1;
- BSRR sets all bits that are 0 to 0.

Therefore this commit removes the 'BSRR with all 0s' code,
which is for now superfluous, since
immediately afterwards ODR is used to set all bits.

Later BRR and BSRR might come in handy,
if one wants to set/reset a single bit
without knowing the values of the other bits.
But it looks like svd4zig's generated code
currently does a read anyway?