### PR TITLE
Switch to microzig master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/microzig"]
 	path = libs/microzig
-	url = https://github.com/marnix/microzig
+	url = https://github.com/ZigEmbeddedGroup/microzig

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ See [rbino's blogpost](https://rbino.com/posts/zig-stm32-blink/) for a more thor
 what's going on.
 
 Since then, this project has been updated to build on top of
-[microzig](https://github.com/ZigEmbeddedGroup/microzig);
-currently it requires my not-yet-merged PR
-https://github.com/ZigEmbeddedGroup/microzig/pull/11.
+[microzig](https://github.com/ZigEmbeddedGroup/microzig).
 
 ## Build
 


### PR DESCRIPTION
This makes no actual change, but now that https://github.com/ZigEmbeddedGroup/microzig/pull/11 has been merged I can switch to its the master branch.