### PR TITLE
I2C 'heavy LED': use latest I2C API

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -177,7 +177,7 @@ fn heavyLed(system: *System) !void {
         // set CTRL_REG1 (0x20) to 100 Hz (.ODR==0b0101),
         // normal power mode (.LPen==1),
         // Y/X both enabled (.Zen==0, .Yen==.Xen==1)
-        const wt = xl.transfer(.write);
+        var wt = try xl.startTransfer(.write);
         {
             defer wt.stop();
             try wt.writer().writeAll(&.{ 0x20, 0b01010011 });
@@ -280,7 +280,7 @@ fn twoBumpingLeds(system: *System) !void {
         // set CTRL_REG1 (0x20) to 100 Hz (.ODR==0b0101),
         // normal power mode (.LPen==1),
         // Z/Y/X all enabled (.Zen==.Yen==.Xen==1)
-        const wt = xl.transfer(.write);
+        var wt = try xl.startTransfer(.write);
         {
             defer wt.stop();
             try wt.writer().writeAll(&.{ 0x20, 0b01010111 });

--- a/src/main.zig
+++ b/src/main.zig
@@ -173,16 +173,11 @@ fn heavyLed(system: *System) !void {
     const i2c1 = try microzig.I2CController(1).init();
     // STM32F3DISCOVERY board LSM303AGR accelerometer (I2C address 0b0011001)
     const xl = i2c1.device(0b0011001);
-    {
-        // set CTRL_REG1 (0x20) to 100 Hz (.ODR==0b0101),
-        // normal power mode (.LPen==1),
-        // Y/X both enabled (.Zen==0, .Yen==.Xen==1)
-        var wt = try xl.startTransfer(.write);
-        {
-            defer wt.stop() catch {};
-            try wt.writer().writeAll(&.{ 0x20, 0b01010011 });
-        }
-    }
+
+    // set CTRL_REG1 (0x20) to 100 Hz (.ODR==0b0101),
+    // normal power mode (.LPen==1),
+    // Y/X both enabled (.Zen==0, .Yen==.Xen==1)
+    try xl.writeRegister(0x20, 0b01010011);
 
     var current_led: ?u3 = null; // led initially off
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -179,7 +179,7 @@ fn heavyLed(system: *System) !void {
         // Y/X both enabled (.Zen==0, .Yen==.Xen==1)
         var wt = try xl.startTransfer(.write);
         {
-            defer wt.stop();
+            defer wt.stop() catch {};
             try wt.writer().writeAll(&.{ 0x20, 0b01010011 });
         }
     }


### PR DESCRIPTION
This now uses the I2C API in latest microzig, and its STM32F303 implementation.