### PR TITLE
Update to latest microzig master

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -1,4 +1,4 @@
-name: Build with zig 0.9.x
+name: Build with zig master
 
 on:
   push:
@@ -15,6 +15,6 @@ jobs:
           submodules: recursive
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.1
+          version: master
       - run: zig build
       - run: zig fmt --check build.zig *.zig

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build with Zig 0.9.0](https://github.com/marnix/zig-stm32f3discovery-play/workflows/Build%20with%20zig%200.9.x/badge.svg?branch=zig-0.9.x)](https://github.com/marnix/zig-stm32f3discovery-play/actions?query=branch%3Azig-0.9.x)
+[![Build with Zig master](https://github.com/marnix/zig-stm32f3discovery-play/workflows/Build%20with%20zig%20master/badge.svg?branch=zig-master)](https://github.com/marnix/zig-stm32f3discovery-play/actions?query=branch%3Azig-master)
 
-_This branch assumes you use Zig 0.9.1._
+_This branch assumes you use Zig master._
 
 # Playing around with pure-Zig STM32F3DISCOVERY
 


### PR DESCRIPTION
This requires:

 - compile with zig master;
 - supply new UART and I2C config information;
 - not use `microzig.panic` anymore;
 - handle error now returned by I2C `stop()`.